### PR TITLE
typo: cgroups cpuset path error and github_repo link & delete obsolete key

### DIFF
--- a/content/en/docs/Getting started/Colocation quick start/_index.md
+++ b/content/en/docs/Getting started/Colocation quick start/_index.md
@@ -166,7 +166,7 @@ exit
 fi
 
 date
-cat /sys/fs/cgroup/cpuset/"$cp"/cpuset.cpus
+cat /sys/fs/cgroup"$cp"/cpuset.cpus
 EOF
 
 chmod 700 /tmp/get_cpuset.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
 
   site:

--- a/hugo.toml
+++ b/hugo.toml
@@ -126,7 +126,7 @@ version = "v0.3.0"
 url_latest_version = "https://example.com"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/kubewharf/katalyst-core"
+github_repo = "https://github.com/kubewharf/katalyst-website"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = "https://github.com/kubewharf/katalyst-core"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.


### PR DESCRIPTION
current doc's shell script will result to:
```bash
root@debian-node-2:~# /tmp/get_cpuset.sh shared-normal-pod
Monday, June 10, 2024 PM11:54:48 HKT
cat: /sys/fs/cgroup/cpuset//kubepods/pod86c1bc18-5bac-4793-8b42-b9878441797e/cffed980ed15f54a5689fbf2efe4680d4bef5bc22ea09b7feccdc26decd1c7e3/cpuset.cpus: No such file or directory
```

we can notice that we have an extra `/cpuset/`

meanwhile I delete the `version` key in `docker-compose.yml` bcz it's obsolete